### PR TITLE
fix: remove duplicate Terraform outputs

### DIFF
--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,12 +1,3 @@
-output "network_id" {
-  description = "ID of the created Docker network"
-  value       = docker_network.iac_network.id
-}
-
-output "network_name" {
-  description = "Name of the created Docker network"
-  value       = docker_network.iac_network.name
-}
 
 output "network_subnet" {
   description = "Subnet of the created Docker network"


### PR DESCRIPTION
- Remove duplicate network_id and network_name outputs from outputs.tf
- These outputs are already defined in main.tf
- Fixes Terraform initialization error: 'Duplicate output definition'
- Resolves make plan && make apply failure